### PR TITLE
 Add support to load services from service provider class

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,7 @@ See more in [Phalcon Documentation](https://docs.phalcon.io/4.0/en/introduction)
 - [Bootstrapping](#bootstrapping)
 - [Modules](#modules)
 - [Collections](#collections)
-- [Providers](#providers)
+- [Services](#services)
 - [Models](#models)
 - [Test](https://github.com/gralhao/gralhao-test)
 
@@ -50,7 +50,7 @@ $bootstrap->setRootPath(__DIR__)->init();
 
 ### Modules <a name="modules"></a>
 In Gralhao, modules are just an alternative way to put your Phalcon code together.
-Modules has a standard to load collections and providers from only one entry point, the ``Module.php`` file.
+Modules has a standard to load collections and services from only one entry point, the ``Module.php`` file.
 
 ##### Creating a module
 Module classes need extends from ``Gralhao\Module``. And implements ``getConfig`` method, to return a module setup array.
@@ -63,7 +63,7 @@ declare(strict_types=1);
 namespace Flying;
 
 use Flying\Collections\FlyingCollection;
-use Flying\Providers\FlyingProvider;
+use Flying\Services\FlyingService;
 
 class Module extends \Gralhao\Module
 {
@@ -73,8 +73,8 @@ class Module extends \Gralhao\Module
             'collections' => [
                 FlyingCollection::class,
             ],
-            'providers' => [
-                'flyingProvider' => FlyingProvider::class,
+            'services' => [
+                'flyingService' => FlyingService::class,
             ]
         ];
     }
@@ -168,20 +168,19 @@ class Module extends \Gralhao\Module
 }
 
 ```
-### Providers <a name="providers"></a>
-Providers are services and classes stored in a Service Locator.
-Read more about [Phalcon Dependency Injection](https://docs.phalcon.io/4.0/pt-br/di).
+### Services <a name="services"></a>
+Services can be registred from a service class or a service provider.
+To see more about, please check [Phalcon DI Documentation](https://docs.phalcon.io/4.0/pt-br/di).
 
-##### Providers Registration
-Provider classe:
+Service classe:
 ```php
 <?php
 
 declare(strict_types=1);
 
-namespace Flying\Providers;
+namespace Flying\Services;
 
-class FlyingProvider
+class FlyingService
 {
     public function foo(): bool
     {
@@ -190,7 +189,9 @@ class FlyingProvider
 }
 
 ```
-Simple Registration
+
+##### Registering from service class
+
 ```php
 <?php
 
@@ -199,7 +200,7 @@ declare(strict_types=1);
 namespace Flying;
 
 use Flying\Collections\FlyingCollection;
-use Flying\Providers\FlyingProvider;
+use Flying\Services\FlyingService;
 
 class Module extends \Gralhao\Module
 {
@@ -209,35 +210,10 @@ class Module extends \Gralhao\Module
             'collections' => [
                 FlyingCollection::class,
             ],
-            'providers' => [
-                'flyingProvider' => FlyingProvider::class,
-            ]
-        ];
-    }
-}
-```
-Complex Registration [Read More](https://docs.phalcon.io/4.0/pt-br/di#complex-registration)
-```php
-<?php
-
-declare(strict_types=1);
-
-namespace Flying;
-
-use Flying\Collections\FlyingCollection;
-use Flying\Providers\FlyingProvider;
-
-class Module extends \Gralhao\Module
-{
-    public function getconfig(): array
-    {
-        return [
-            'collections' => [
-                FlyingCollection::class,
-            ],
-            'providers' => [
-                'flyingProvider' => [
-                    'className'  => FlyingProvider::class,
+            'services' => [
+                'flyingService' => FlyingService::class,
+                'flyingServiceUsingComplexRegistration' => [
+                    'className'  => FlyingService::class,
                     'shared'     => true,
                     // 'arguments'  => [],
                     // 'calls'      => [],
@@ -248,7 +224,55 @@ class Module extends \Gralhao\Module
     }
 }
 ```
-##### Using Providers
+See more about [Complex Registration](https://docs.phalcon.io/4.0/pt-br/di#complex-registration).
+
+##### Registering from service provider
 ```php
-echo $this->di->get('flyingProvider')->foo(); // True
+<?php
+
+declare(strict_types=1);
+
+namespace Flying\Services;
+
+use Phalcon\Di\DiInterface;
+use Phalcon\Di\ServiceProviderInterface;
+
+class FlyingServiceProvider implements ServiceProviderInterface
+{
+    public function register(DiInterface $container): void
+    {
+        $container->set('flyingService', FlyingService::class);
+    }
+}
+
+```
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Flying;
+
+use Flying\Collections\FlyingCollection;
+use Flying\Services\FlyingServiceProvider;
+
+class Module extends \Gralhao\Module
+{
+    public function getconfig(): array
+    {
+        return [
+            'collections' => [
+                FlyingCollection::class,
+            ],
+            'service_provider' => [
+                FlyingServiceProvider::class,
+            ],
+        ];
+    }
+}
+```
+##### Using Services
+```php
+echo $this->di->get('flyingService')->foo(); // True
 ```

--- a/src/Loader/ModulesLoader.php
+++ b/src/Loader/ModulesLoader.php
@@ -37,9 +37,8 @@ final class ModulesLoader extends Injectable
                         case 'service_providers':
                             $container->register(new $value());
                             break;
-                        case 'providers':
                         case 'services':
-                            $this->di->set($key, $value);
+                            $container->set($key, $value);
                             break;
                     }
                 }

--- a/src/Loader/ModulesLoader.php
+++ b/src/Loader/ModulesLoader.php
@@ -25,6 +25,8 @@ final class ModulesLoader extends Injectable
      */
     public function load(Micro $app): void
     {
+        /** @var \Phalcon\Di */
+        $container = $this->di;
         foreach ($this->getModulesConfig() as $configs) {
             foreach ($configs as $type => $classes) {
                 foreach ($classes as $key => $value) {
@@ -32,7 +34,11 @@ final class ModulesLoader extends Injectable
                         case 'collections':
                             $app->mount(new $value());
                             break;
+                        case 'service_providers':
+                            $container->register(new $value());
+                            break;
                         case 'providers':
+                        case 'services':
                             $this->di->set($key, $value);
                             break;
                     }

--- a/test/App/AppTest.php
+++ b/test/App/AppTest.php
@@ -49,7 +49,8 @@ class AppTest extends \Gralhao\Test\TestCase
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals('test', $response->data->body);
         $this->assertEquals('value', $response->data->headers->key);
-        $this->assertTrue($response->data->fromProvider);
+        $this->assertTrue($response->data->fromService);
+        $this->assertTrue($response->data->fromServiceProvider);
     }
 
     public function testReturnAValidErrorRequestResponse(): void

--- a/test/App/Modules/Demo/DemoController.php
+++ b/test/App/Modules/Demo/DemoController.php
@@ -9,10 +9,11 @@ class DemoController extends \Gralhao\Controller
     public function success(): void
     {
         $this->send([
-            'body'    => $this->request->getRawBody(),
-            'headers' => $this->request->getHeaders(),
-            'method'  => $this->request->getMethod(),
-            'fromProvider' => $this->di->get('complexRegistredProvider')->data(),
+            'body'                => $this->request->getRawBody(),
+            'headers'             => $this->request->getHeaders(),
+            'method'              => $this->request->getMethod(),
+            'fromService'         => $this->di->get('complexRegistredService')->data(),
+            'fromServiceProvider' => $this->di->get('serviceRegistredFromProvider')->data(),
         ]);
     }
 

--- a/test/App/Modules/Demo/DemoService.php
+++ b/test/App/Modules/Demo/DemoService.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace GralhaoTest\App\Modules\Demo;
 
-class DemoProvider
+class DemoService
 {
     public function data(): bool
     {

--- a/test/App/Modules/Demo/DemoServiceProvider.php
+++ b/test/App/Modules/Demo/DemoServiceProvider.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace GralhaoTest\App\Modules\Demo;
+
+use Phalcon\Di\DiInterface;
+use Phalcon\Di\ServiceProviderInterface;
+
+class DemoServiceProvider implements ServiceProviderInterface
+{
+    public function register(DiInterface $container): void
+    {
+        $container->set('serviceRegistredFromProvider', DemoService::class);
+    }
+}

--- a/test/App/Modules/Demo/Module.php
+++ b/test/App/Modules/Demo/Module.php
@@ -12,15 +12,18 @@ class Module extends \Gralhao\Module
             'collections' => [
                 DemoCollection::class,
             ],
-            'providers' => [
-                'simpleRegistredProvider'   => DemoProvider::class,
-                'complexRegistredProvider' => [
-                    'className'  => DemoProvider::class,
+            'services' => [
+                'simpleRegistredService'  => DemoService::class,
+                'complexRegistredService' => [
+                    'className'  => DemoService::class,
                     'shared'     => true,
                     'arguments'  => [],
                     'calls'      => [],
                     'properties' => []
                 ],
+            ],
+            'service_providers' => [
+                DemoServiceProvider::class
             ]
         ];
     }


### PR DESCRIPTION
Now is possible to load services from a service provider.
```php
use Phalcon\Di\DiInterface;
use Phalcon\Di\ServiceProviderInterface;

class ServiceProvider implements ServiceProviderInterface
{
    public function register(DiInterface $container): void
    {
        $container->set('service', Service::class);
    }
}
```
```php
class Module extends \Gralhao\Module
{
    public function getconfig(): array
    {
        return [
            'service_providers' => [
                ServiceProvider::class
            ]
        ];
    }
}
```